### PR TITLE
feat(bigtable): allow restore backup to different instance

### DIFF
--- a/bigtable/admin.go
+++ b/bigtable/admin.go
@@ -1459,11 +1459,12 @@ func (ac *AdminClient) RestoreTable(ctx context.Context, table, cluster, backup 
 }
 
 // RestoreTableTo creates a new table by restoring from this completed backup.
-// instance is an instance in which the new table will be created and restored to.
+//
+// diffInstance is an instance in which the new table will be restored to.
 // Instance must be in the same project as the project containing backup.
-func (ac *AdminClient) RestoreTableTo(ctx context.Context, instance, table, cluster, backup string) error {
+func (ac *AdminClient) RestoreTableTo(ctx context.Context, diffInstance, table, cluster, backup string) error {
 	ctx = mergeOutgoingMetadata(ctx, ac.md)
-	prefix := "projects/" + ac.project + "/instances/" + instance
+	prefix := "projects/" + ac.project + "/instances/" + diffInstance
 	backupPath := "projects/" + ac.project + "/instances/" + ac.instance + "/clusters/" + cluster + "/backups/" + backup
 
 	req := &btapb.RestoreTableRequest{

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -2033,6 +2033,26 @@ func TestIntegration_AdminBackup(t *testing.T) {
 	table := testEnv.Config().Table
 	cluster := testEnv.Config().Cluster
 
+	iAdminClient, err := testEnv.NewInstanceAdminClient()
+	if err != nil {
+		t.Fatalf("NewInstanceAdminClient: %v", err)
+	}
+	defer iAdminClient.Close()
+	destInstance := testEnv.Config().Instance + "-dest"
+	destCluster := cluster + "-dest"
+	conf := &InstanceConf{
+		InstanceId:   destInstance,
+		ClusterId:    destCluster,
+		DisplayName:  "destinastion test instance",
+		Zone:         instanceToCreateZone,
+		InstanceType: DEVELOPMENT,
+		Labels:       map[string]string{"test-label-key": "test-label-value"},
+	}
+	defer iAdminClient.DeleteInstance(ctx, destInstance)
+	// Create different instance to restore table.
+	if err := iAdminClient.CreateInstance(ctx, conf); err != nil {
+		t.Fatalf("CreateInstance: %v", err)
+	}
 	// Delete the table at the end of the test. Schedule ahead of time
 	// in case the client fails
 	defer deleteTable(ctx, t, adminClient, table)
@@ -2127,6 +2147,12 @@ func TestIntegration_AdminBackup(t *testing.T) {
 	}
 	if _, err := adminClient.TableInfo(ctx, restoredTable); err != nil {
 		t.Fatalf("Restored TableInfo: %v", err)
+	}
+	// Restore backup to different instance
+	diffTable := table + "-diff-restored"
+	defer deleteTable(ctx, t, adminClient, diffTable)
+	if err = adminClient.RestoreTableTo(ctx, destInstance, diffTable, cluster, "mybackup"); err != nil {
+		t.Fatalf("RestoreTableTo: %v", err)
 	}
 
 	// Delete backup

--- a/bigtable/integration_test.go
+++ b/bigtable/integration_test.go
@@ -2044,7 +2044,7 @@ func TestIntegration_AdminBackup(t *testing.T) {
 		InstanceId:   diffInstance,
 		ClusterId:    diffCluster,
 		DisplayName:  "different test instance",
-		Zone:         instanceToCreateZone,
+		Zone:         instanceToCreateZone2,
 		InstanceType: DEVELOPMENT,
 		Labels:       map[string]string{"test-label-key": "test-label-value"},
 	}


### PR DESCRIPTION
Currently have this error on grass-clump-479:
![image](https://user-images.githubusercontent.com/38891896/102782439-66046f00-43aa-11eb-8504-1b6d8dfa2ae2.png)
[Doc](https://docs.google.com/document/d/161aGBaZDoRommfMzI6a8QqgrWwZxNCrFPGAGX0ECcDU/edit?ts=5fd8d36b#)